### PR TITLE
Add cloud and platform CLIs (gcloud, Supabase, Firebase, Vercel, Heroku, Expo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ installs.
 | Git | git, git-lfs, delta, lazygit, GitHub CLI, pre-commit, a large alias set |
 | Containers | Docker Engine + Compose v2 + Buildx (Linux), Colima or Docker Desktop (macOS), lazydocker, dive, ctop |
 | Kubernetes | kubectl, helm, k9s, kind, kubectx/kubens, stern |
-| Cloud | AWS CLI v2, Terraform, Ansible |
+| Cloud | AWS CLI v2, Google Cloud CLI, Terraform, Ansible |
+| Platforms | Supabase, Firebase, Vercel, Heroku and Expo (EAS) CLIs, GitHub CLI |
 | Languages | Node (nvm), Python (pipx + uv + poetry), Go, Rust (rustup), Java/Maven/Gradle (SDKMAN), PHP + Composer + Laravel, Ruby (rbenv) |
 | Databases | psql, mysql/mariadb, redis, sqlite clients plus pgcli and mycli |
 | Editors | vim (vim-plug), Neovim, VS Code, JetBrains Toolbox and Sublime on macOS |
@@ -55,7 +56,7 @@ them per-project with `docker compose`, and keep only the clients locally.
 │   └── shell.sh                  oh-my-zsh and prompt setup
 ├── packages/                     Homebrew bundles
 │   ├── Brewfile                  core CLI toolchain
-│   ├── Brewfile.extras           cloud, Kubernetes, databases
+│   ├── Brewfile.extras           cloud, Kubernetes, platform CLIs, databases
 │   └── Brewfile.casks            GUI applications and fonts
 └── macos/defaults.sh             opinionated macOS system preferences
 ```
@@ -141,6 +142,53 @@ Desktop; nothing else in the configuration changes.
 Useful aliases: `dc` (compose), `dcu`/`dcd` (up/down), `dcl` (logs), `dps`
 (formatted `ps`), `dprune` (reclaim disk), `dsh <container>` (shell inside a
 container), `ld` (lazydocker).
+
+---
+
+## Cloud and platform CLIs
+
+The `cloud` module (Linux) and `packages/Brewfile.extras` (macOS) install the
+same set of tools by whichever route each vendor actually supports:
+
+| CLI | Command | Linux | macOS |
+| --- | --- | --- | --- |
+| AWS | `aws` | official v2 installer | `awscli` formula |
+| Google Cloud | `gcloud` | `cloud-sdk` apt repository | `gcloud-cli` cask |
+| GitHub | `gh` | `cli.github.com` apt repository (`cli` module) | `gh` formula |
+| Supabase | `supabase` | `.deb` from GitHub releases | `supabase` formula |
+| Firebase | `firebase` | `firebase-tools` on npm | `firebase-cli` formula |
+| Vercel | `vercel` | `vercel` on npm | `vercel` formula |
+| Heroku | `heroku` | `heroku` on npm | `heroku` formula |
+| Expo | `eas` | `eas-cli` on npm | `eas-cli` formula |
+
+A couple of choices worth knowing about:
+
+- **Supabase is never installed from npm.** Upstream does not support a global
+  npm install, so Linux takes the published `.deb` instead.
+- **`expo-cli` is deprecated.** `eas` handles builds and submissions; inside a
+  project the CLI is the local one, which is why `.aliases` maps `expo` to
+  `npx expo`.
+- On Linux the npm-only CLIs are global packages of the nvm-managed Node, so
+  they need reinstalling after switching to a Node version you have not used
+  before: `./setup-linux-workstation.sh --only cloud`.
+- `google-cloud-cli-gke-gcloud-auth-plugin` comes along with `gcloud` on Linux,
+  because `kubectl` cannot authenticate against GKE without it.
+
+Signing in is deliberately left to you — nothing here writes a credential:
+
+```bash
+aws configure sso           # or: aws configure
+gcloud auth login --update-adc
+gh auth login
+supabase login
+firebase login
+vercel login
+heroku login
+eas login
+```
+
+Handy aliases: `awswho` / `gcwho` (which identity am I using), `gcproj`
+(set the active project), `sb`, `fb`, `vc`, `vcp` (`vercel deploy --prod`).
 
 ---
 

--- a/home/.aliases
+++ b/home/.aliases
@@ -113,6 +113,35 @@ alias kgs='kubectl get svc'
 alias kaf='kubectl apply -f'
 
 # ---------------------------------------------------------------------------
+# Cloud & deploy
+# ---------------------------------------------------------------------------
+
+# Which account am I about to deploy with? Worth checking before anything else.
+alias awswho='aws sts get-caller-identity'
+alias gcwho='gcloud auth list'
+
+# No short `gc*` alias for gcloud itself: oh-my-zsh's git plugin owns that
+# prefix, and silently shadowing `git commit` is not worth three keystrokes.
+alias gcproj='gcloud config set project'
+alias gclogin='gcloud auth login --update-adc'
+
+alias sb='supabase'
+alias sbstart='supabase start'
+alias sbstatus='supabase status'
+alias sbdiff='supabase db diff'
+
+alias fb='firebase'
+alias fbd='firebase deploy'
+alias fbe='firebase emulators:start'
+
+alias vc='vercel'
+alias vcd='vercel deploy'
+alias vcp='vercel deploy --prod'
+
+# Expo: eas builds and submits, `expo` itself is meant to run from the project.
+alias expo='npx expo'
+
+# ---------------------------------------------------------------------------
 # Languages & frameworks
 # ---------------------------------------------------------------------------
 

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -214,6 +214,12 @@ if [[ ! -d "$_dotfiles_completions" ]]; then
   command -v helm >/dev/null 2>&1 && helm completion zsh >"${_dotfiles_completions}/_helm"
   command -v gh >/dev/null 2>&1 && gh completion -s zsh >"${_dotfiles_completions}/_gh"
   command -v terraform >/dev/null 2>&1 && terraform -install-autocomplete 2>/dev/null
+  # Recent Supabase releases moved from `completion zsh` to `--completions zsh`.
+  if command -v supabase >/dev/null 2>&1; then
+    supabase --completions zsh >"${_dotfiles_completions}/_supabase" 2>/dev/null ||
+      supabase completion zsh >"${_dotfiles_completions}/_supabase" 2>/dev/null ||
+      command rm -f "${_dotfiles_completions}/_supabase"
+  fi
 fi
 fpath=("$_dotfiles_completions" $fpath)
 unset _dotfiles_completions
@@ -225,6 +231,22 @@ if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
 else
   compinit -C
 fi
+
+# The Google Cloud SDK ships its own PATH and completion snippets. They call
+# compdef, so they have to come after compinit. Homebrew's cask, the apt
+# package, the snap and a manual tarball each land somewhere different.
+for _gcloud_dir in \
+  "${HOMEBREW_PREFIX:-/opt/homebrew}/share/google-cloud-sdk" \
+  /usr/share/google-cloud-sdk \
+  /snap/google-cloud-cli/current \
+  "${HOME}/google-cloud-sdk"; do
+  if [[ -f "${_gcloud_dir}/completion.zsh.inc" ]]; then
+    [[ -f "${_gcloud_dir}/path.zsh.inc" ]] && source "${_gcloud_dir}/path.zsh.inc"
+    source "${_gcloud_dir}/completion.zsh.inc"
+    break
+  fi
+done
+unset _gcloud_dir
 
 # ---------------------------------------------------------------------------
 # Machine-specific overrides (secrets, work config, one-off PATH entries)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -166,6 +166,54 @@ selected() {
 }
 
 # ---------------------------------------------------------------------------
+# Node
+# ---------------------------------------------------------------------------
+
+# load_nvm — put an nvm-managed Node on PATH for the rest of the script.
+# Setup scripts never read ~/.zshrc, so a Node installed by the node module
+# earlier in the same run is otherwise invisible to later modules.
+load_nvm() {
+  has npm && return 0
+  local nvm_dir="${NVM_DIR:-${HOME}/.nvm}"
+  [[ -s "${nvm_dir}/nvm.sh" ]] || return 1
+  # nvm's own scripts are not written for `set -euo pipefail`.
+  set +eu
+  # shellcheck disable=SC1091
+  . "${nvm_dir}/nvm.sh"
+  nvm use default >/dev/null 2>&1
+  set -eu
+  has npm
+}
+
+# npm_global_install <packages...> — install the globals that are missing.
+# A package that fails warns rather than aborting the module.
+npm_global_install() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    printf '%s  would run:%s npm install -g %s\n' "$C_DIM" "$C_RESET" "$*"
+    return 0
+  fi
+  if ! load_nvm; then
+    warn "npm not available; skipping global packages: $*"
+    return 0
+  fi
+
+  local installed missing=() pkg
+  installed="$(npm ls -g --depth=0 --parseable 2>/dev/null || true)"
+  for pkg in "$@"; do
+    if printf '%s\n' "$installed" | grep -qE "/${pkg}\$"; then
+      skip "npm ${pkg} already installed"
+    else
+      missing+=("$pkg")
+    fi
+  done
+  [[ ${#missing[@]} -eq 0 ]] && return 0
+
+  info "Installing npm globals: ${missing[*]}"
+  npm install -g "${missing[@]}" || warn "npm install -g failed: ${missing[*]}"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Downloads
 # ---------------------------------------------------------------------------
 

--- a/packages/Brewfile.extras
+++ b/packages/Brewfile.extras
@@ -17,6 +17,18 @@ brew "awscli"
 brew "hashicorp/tap/terraform"
 brew "ansible"
 brew "flyctl"
+# The Google Cloud CLI is only packaged as a cask, but it is a command line
+# tool, so it belongs here rather than in Brewfile.casks.
+cask "gcloud-cli"
+
+# --- Application platforms ---------------------------------------------------
+# The Linux script installs the npm-only ones through npm; on macOS every one
+# of these has a formula, which keeps them out of the nvm-managed global set.
+brew "supabase"
+brew "firebase-cli"
+brew "vercel"
+brew "heroku"
+brew "eas-cli"        # Expo: `eas` for builds, `npx expo` inside a project
 
 # --- Databases ---------------------------------------------------------------
 # Clients only — run the servers themselves in containers.

--- a/setup-linux-workstation.sh
+++ b/setup-linux-workstation.sh
@@ -41,7 +41,7 @@ declare -A MODULE_DESC=(
   [ruby]="rbenv and ruby-build"
   [db]="Database clients (psql, mariadb, redis, sqlite, pgcli, mycli)"
   [k8s]="kubectl, helm, k9s, kind, kubectx/kubens"
-  [cloud]="AWS CLI v2, Terraform, Ansible"
+  [cloud]="AWS, gcloud, Terraform, Ansible and the deploy CLIs (supabase, firebase, vercel, heroku, eas)"
   [editors]="Visual Studio Code"
   [apps]="GUI apps: browsers, Slack, Discord, Postman, Signal, VLC"
   [fonts]="JetBrains Mono / FiraCode Nerd Fonts and powerline fonts"
@@ -250,8 +250,9 @@ module_node() {
     corepack enable
     corepack prepare yarn@stable pnpm@latest --activate
   fi
+  # Deploy CLIs (vercel, firebase, heroku, eas) live in the cloud module.
   npm install -g npm@latest typescript ts-node tsx eslint prettier \
-    serve nodemon npm-check-updates vercel
+    serve nodemon npm-check-updates
   set -eu
 }
 
@@ -440,12 +441,26 @@ module_cloud() {
     rm -rf "$tmp"
   fi
 
+  # Google Cloud CLI. The gke auth plugin is what kubectl needs to talk to GKE.
+  add_apt_repo google-cloud \
+    "https://packages.cloud.google.com/apt/doc/apt-key.gpg" \
+    "deb [arch=$(deb_arch) signed-by=${KEYRING_DIR}/google-cloud.gpg] https://packages.cloud.google.com/apt cloud-sdk main" &&
+    apt_install google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
+
   add_apt_repo hashicorp \
     "https://apt.releases.hashicorp.com/gpg" \
     "deb [arch=$(deb_arch) signed-by=${KEYRING_DIR}/hashicorp.gpg] https://apt.releases.hashicorp.com $(ubuntu_codename) main" &&
     apt_install terraform
 
   apt_install ansible
+
+  # Supabase publishes .deb packages; a global npm install is explicitly
+  # unsupported upstream, so this one does not go through npm_global_install.
+  install_deb_from_github "supabase/cli" "supabase_.*_linux_$(deb_arch)\.deb\$" supabase
+
+  # The remaining platform CLIs only ship on npm. `expo-cli` is deprecated:
+  # eas-cli covers builds and submissions, and projects run `npx expo` locally.
+  npm_global_install vercel firebase-tools heroku eas-cli
 }
 
 module_editors() {

--- a/setup-macos-workstation.sh
+++ b/setup-macos-workstation.sh
@@ -370,7 +370,10 @@ main() {
   done
 
   header "Done"
-  success "Modules completed: ${ran[*]}"
+  # ${ran[*]:-} rather than ${ran[*]}: on bash 3.2 expanding an empty array
+  # under `set -u` is itself an "unbound variable" error, which would turn a
+  # mistyped --only into a crash instead of an empty summary line.
+  success "Modules completed: ${ran[*]:-}"
   [[ ${#failed[@]} -gt 0 ]] && warn "Modules with errors: ${failed[*]}"
   cat <<EOF
 

--- a/setup-macos-workstation.sh
+++ b/setup-macos-workstation.sh
@@ -24,7 +24,7 @@ MODULES=(core brew extras casks shell docker node python java rust defaults)
 declare -A MODULE_DESC=(
   [core]="Xcode Command Line Tools, Rosetta 2 and Homebrew"
   [brew]="Core CLI toolchain from packages/Brewfile"
-  [extras]="Cloud, Kubernetes and database tooling from packages/Brewfile.extras"
+  [extras]="Cloud, Kubernetes, platform CLIs and database tooling from packages/Brewfile.extras"
   [casks]="GUI applications and Nerd Fonts from packages/Brewfile.casks"
   [shell]="oh-my-zsh, spaceship prompt, autosuggestions, syntax highlighting"
   [docker]="Container runtime (Colima by default, or Docker Desktop)"
@@ -264,8 +264,9 @@ module_node() {
     corepack enable
     corepack prepare yarn@stable pnpm@latest --activate
   fi
+  # Deploy CLIs (vercel, firebase, heroku, eas) come from Brewfile.extras.
   npm install -g npm@latest typescript ts-node tsx eslint prettier \
-    serve nodemon npm-check-updates vercel
+    serve nodemon npm-check-updates
   set -eu
 }
 

--- a/setup-macos-workstation.sh
+++ b/setup-macos-workstation.sh
@@ -21,19 +21,26 @@ source "${SCRIPT_DIR}/lib/shell.sh"
 
 MODULES=(core brew extras casks shell docker node python java rust defaults)
 
-declare -A MODULE_DESC=(
-  [core]="Xcode Command Line Tools, Rosetta 2 and Homebrew"
-  [brew]="Core CLI toolchain from packages/Brewfile"
-  [extras]="Cloud, Kubernetes, platform CLIs and database tooling from packages/Brewfile.extras"
-  [casks]="GUI applications and Nerd Fonts from packages/Brewfile.casks"
-  [shell]="oh-my-zsh, spaceship prompt, autosuggestions, syntax highlighting"
-  [docker]="Container runtime (Colima by default, or Docker Desktop)"
-  [node]="nvm, Node.js LTS, corepack (yarn/pnpm) and global CLIs"
-  [python]="pipx-managed Python tooling (poetry, ruff, black, pre-commit)"
-  [java]="SDKMAN with the current Java LTS, Maven and Gradle"
-  [rust]="rustup, cargo, clippy, rustfmt"
-  [defaults]="Opinionated macOS system defaults (opt-in via --defaults)"
-)
+# macOS still ships bash 3.2, which has no associative arrays: `declare -A`
+# there is parsed as an indexed array and dies on the first subscript with
+# "core: unbound variable". This script is what installs a newer bash in the
+# first place, so it has to run on the stock one — hence a lookup function.
+module_desc() {
+  case "$1" in
+    core) printf '%s' "Xcode Command Line Tools, Rosetta 2 and Homebrew" ;;
+    brew) printf '%s' "Core CLI toolchain from packages/Brewfile" ;;
+    extras) printf '%s' "Cloud, Kubernetes, platform CLIs and database tooling from packages/Brewfile.extras" ;;
+    casks) printf '%s' "GUI applications and Nerd Fonts from packages/Brewfile.casks" ;;
+    shell) printf '%s' "oh-my-zsh, spaceship prompt, autosuggestions, syntax highlighting" ;;
+    docker) printf '%s' "Container runtime (Colima by default, or Docker Desktop)" ;;
+    node) printf '%s' "nvm, Node.js LTS, corepack (yarn/pnpm) and global CLIs" ;;
+    python) printf '%s' "pipx-managed Python tooling (poetry, ruff, black, pre-commit)" ;;
+    java) printf '%s' "SDKMAN with the current Java LTS, Maven and Gradle" ;;
+    rust) printf '%s' "rustup, cargo, clippy, rustfmt" ;;
+    defaults) printf '%s' "Opinionated macOS system defaults (opt-in via --defaults)" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
 
 # `defaults` mutates system preferences, so it is opt-in rather than opt-out.
 SKIP_MODULES="defaults"
@@ -64,7 +71,7 @@ list_modules() {
   printf '%sAvailable modules%s\n' "$C_BOLD" "$C_RESET"
   local m
   for m in "${MODULES[@]}"; do
-    printf '  %-9s %s\n' "$m" "${MODULE_DESC[$m]}"
+    printf '  %-9s %s\n' "$m" "$(module_desc "$m")"
   done
 }
 
@@ -352,7 +359,7 @@ main() {
   local module ran=() failed=()
   for module in "${MODULES[@]}"; do
     if selected "$module"; then
-      header "${module} — ${MODULE_DESC[$module]}"
+      header "${module} — $(module_desc "$module")"
       if "module_${module}"; then
         ran+=("$module")
       else


### PR DESCRIPTION
## Summary
This PR expands the cloud tooling support by adding Google Cloud CLI and several application platform CLIs (Supabase, Firebase, Vercel, Heroku, and Expo). The changes ensure consistent installation across Linux and macOS while respecting each platform's native packaging conventions.

## Key Changes

- **Google Cloud CLI**: Added to both Linux (via apt repository) and macOS (via Homebrew cask), including the GKE authentication plugin required for kubectl to work with GKE
- **Platform CLIs**: Added Supabase, Firebase, Vercel, Heroku, and Expo (eas-cli) with platform-specific installation methods:
  - Linux: Supabase via `.deb` from GitHub releases, others via npm globals
  - macOS: All via Homebrew formulas to keep them separate from nvm-managed packages
- **Helper functions**: Added `load_nvm()` and `npm_global_install()` utilities in `lib/common.sh` to safely manage npm global package installation across script runs
- **Aliases**: Added convenient aliases for cloud operations (`awswho`, `gcwho`, `gcproj`, `sb`, `fb`, `vc`, `vcp`) and platform CLIs
- **Shell integration**: Added zsh completion support for Supabase (handling both old and new completion formats) and Google Cloud SDK (sourcing its own PATH and completion scripts)
- **Documentation**: Updated README with a new "Cloud and platform CLIs" section explaining installation methods, important caveats (Supabase npm limitation, expo-cli deprecation), and login instructions

## Notable Implementation Details

- Supabase is intentionally never installed from npm on Linux, as upstream does not support global npm installation
- `expo-cli` is deprecated; `eas-cli` handles builds/submissions while projects use `npx expo` locally
- npm global packages on Linux are tied to the nvm-managed Node version and require reinstalling when switching versions
- Google Cloud SDK completion is sourced after `compinit` since it calls `compdef`
- Removed `vercel` from the node module's npm install list since it's now handled by the cloud module (macOS) or npm_global_install (Linux)

https://claude.ai/code/session_014CgyZde3jVbbF83s1zZdfj